### PR TITLE
change fd_order checker

### DIFF
--- a/src/simulation/m_checker.fpp
+++ b/src/simulation/m_checker.fpp
@@ -260,7 +260,8 @@ contains
     !> Checks constraints on elasticity parameters
     subroutine s_check_inputs_elasticity
         @:PROHIBIT(hyperelasticity .and. hyper_model == dflt_int)
-        @:PROHIBIT((hypoelasticity .or. hyperelasticity) .and. fd_order /= 4)
+        @:PROHIBIT((hypoelasticity .or. hyperelasticity) .and. fd_order == dflt_int, &
+            "fd_order must be set for hypoelasticity or hyperelasticity")
     end subroutine
 
     !> Checks constraints on bubble parameters


### PR DESCRIPTION
Removed the `fd_order = 4` constraint since the current hypoelasticity test case uses `fd_order = 1`.

Test suites should now pass.